### PR TITLE
Remove unused cython import

### DIFF
--- a/lintegrate/lintegrate.pyx
+++ b/lintegrate/lintegrate.pyx
@@ -16,9 +16,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
-import cython
-cimport cython
-
 import numpy as np
 cimport numpy as np
 


### PR DESCRIPTION
This PR removes an unused import of `cython`; this actually breaks stuff, apparently.