### PR TITLE
Do not include all compiler flags in conda build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ from Cython.Build import cythonize
 
 ROOT = Path(__file__).parent
 WINDOWS = os.name == "nt"
+CONDA = os.environ.get("CONDA_BUILD", 0)
 
 
 def readfile(filename):
@@ -64,6 +65,10 @@ if WINDOWS:
         "-O2",
         "-DGSL_DLL",
         "-DWIN32",
+    ]
+elif CONDA:
+    extra_compile_args += [
+        "-O3",
     ]
 else:
     extra_compile_args += [


### PR DESCRIPTION
I've have been having issues with the lintegrate installed via conda, which gives an `Illegal instruction (core dumped)` error when you try and use it! After some Googling I found a similar error here https://github.com/spectralDNS/shenfun/issues/26, with this comment https://github.com/spectralDNS/shenfun/issues/26#issuecomment-690266220 suggesting it is due to `-march=native` being automatically included in the conda build. In shefun it seems that the fix has been to not include various compiler flags in the conda build https://github.com/spectralDNS/shenfun/commit/a12a24a6cabd5777b3c3b816ee7d7e0331b8067d.

This PR attempts to do this (I've created a new conda build https://github.com/conda-forge/lintegrate-feedstock/pull/27 including this patch to see if it fixes things).