### PR TITLE
Add .pxd file so cdef functions can be used in other packages

### DIFF
--- a/lintegrate/__init__.py
+++ b/lintegrate/__init__.py
@@ -1,3 +1,18 @@
+import os
+
 from .lintegrate import *
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"
+
+
+def get_include():
+    """
+    Get base location containing the lintegrate package. This allows the path
+    to be included in other Cython packages that want to use lintegrate cdef
+    functions.
+    """
+
+    import lintegrate
+
+    return os.path.split(lintegrate.__file__)[0].strip("lintegrate")
+

--- a/lintegrate/lintegrate.pxd
+++ b/lintegrate/lintegrate.pxd
@@ -1,0 +1,31 @@
+import numpy as np
+cimport numpy as np
+
+from numpy.math cimport LOGE2, INFINITY
+
+from libc.math cimport exp, sqrt, log, log10, isinf, fabs
+
+cdef extern from "gsl/gsl_integration.h":
+    void gsl_integration_workspace_free (gsl_integration_workspace * w)
+    ctypedef struct gsl_integration_workspace
+    gsl_integration_workspace * gsl_integration_workspace_alloc (size_t n)
+    void gsl_integration_cquad_workspace_free (gsl_integration_cquad_workspace * w)
+    ctypedef struct gsl_integration_cquad_workspace
+    gsl_integration_cquad_workspace * gsl_integration_cquad_workspace_alloc (size_t n)
+
+cdef extern from "gsl/gsl_sf_log.h":
+    double gsl_sf_log_1plusx(double x)
+
+cdef extern from "lintegrate.h":
+    ctypedef double (*pylintfunc)(double x, void *funcdata, void *args)
+    int lintegration_qng (pylintfunc f, void *funcdata, void *args, double a, double b, double epsabs, double epsrel, double *result, double *abserr, size_t *neval)
+    int lintegration_qag (pylintfunc f, void *funcdata, void *args, double a, double b, double epsabs, double epsrel, size_t limit, int key, gsl_integration_workspace * workspace, double * result, double * abserr)
+    int lintegration_cquad (pylintfunc f, void *funcdata, void *args, double a, double b, double epsabs, double epsrel, gsl_integration_cquad_workspace * ws, double *result, double *abserr, size_t * nevals)
+
+
+DTYPE = np.float64
+ctypedef np.float64_t DTYPE_t
+
+
+cdef double logtrapzC(np.ndarray[DTYPE_t, ndim=1] lx, np.ndarray[DTYPE_t, ndim=1] t)
+cdef double logplus(double x, double y)

--- a/lintegrate/lintegrate.pyx
+++ b/lintegrate/lintegrate.pyx
@@ -19,35 +19,11 @@
 import numpy as np
 cimport numpy as np
 
-from numpy.math cimport LOGE2, INFINITY
-
-from libc.math cimport exp, sqrt, log, log10, isinf, fabs
-
-cdef extern from "gsl/gsl_integration.h":
-    void gsl_integration_workspace_free (gsl_integration_workspace * w)
-    ctypedef struct gsl_integration_workspace
-    gsl_integration_workspace * gsl_integration_workspace_alloc (size_t n)
-    void gsl_integration_cquad_workspace_free (gsl_integration_cquad_workspace * w)
-    ctypedef struct gsl_integration_cquad_workspace
-    gsl_integration_cquad_workspace * gsl_integration_cquad_workspace_alloc (size_t n)
-
-cdef extern from "gsl/gsl_sf_log.h":
-    double gsl_sf_log_1plusx(double x)
-
-cdef extern from "lintegrate.h":
-    ctypedef double (*pylintfunc)(double x, void *funcdata, void *args)
-    int lintegration_qng (pylintfunc f, void *funcdata, void *args, double a, double b, double epsabs, double epsrel, double *result, double *abserr, size_t *neval)
-    int lintegration_qag (pylintfunc f, void *funcdata, void *args, double a, double b, double epsabs, double epsrel, size_t limit, int key, gsl_integration_workspace * workspace, double * result, double * abserr)
-    int lintegration_cquad (pylintfunc f, void *funcdata, void *args, double a, double b, double epsabs, double epsrel, gsl_integration_cquad_workspace * ws, double *result, double *abserr, size_t * nevals)
-
-
 # call import_array() https://cython.readthedocs.io/en/latest/src/tutorial/numpy.html#adding-types
 np.import_array()
 
-DTYPE = np.float64
-ctypedef np.float64_t DTYPE_t
-
 GSL_DBL_EPSILON = 2.2204460492503131e-16
+
 
 cdef double logtrapzC(np.ndarray[DTYPE_t, ndim=1] lx, np.ndarray[DTYPE_t, ndim=1] t):
     assert len(lx) == len(t) or len(t) == 1, "Function and function evaluation points must be the same length, or there must be a single evaluation point spacing given"
@@ -73,7 +49,7 @@ cdef double logtrapzC(np.ndarray[DTYPE_t, ndim=1] lx, np.ndarray[DTYPE_t, ndim=1
         return B + log(t[0])
 
 
-cdef logplus(double x, double y):
+cdef double logplus(double x, double y):
     """
     Calculate :math:`\log{(e^x + e^y)}` in a way that preserves numerical precision.
 
@@ -482,3 +458,4 @@ def lcquad(func, a, b, args=(), epsabs=1.49e-8, epsrel=1.49e-8, wsintervals=100,
 # (see e.g. https://github.com/cython/cython/tree/master/Demos/callback)
 cdef double lintegrate_callback(double x, void *f, void *args):
     return (<object>f)(x, <object>args)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools >= 40.6.0", "cython", "wheel", "numpy"]
+requires = ["setuptools >= 40.6.0", "cython", "wheel", "oldest-supported-numpy"]
 build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,11 +26,15 @@ universal = 1
 python_requires = >=3.7
 setup_requires =
     cython
-    numpy>=1.21
+    numpy
     setuptools_scm
 install_requires = 
     numpy>=1.21
 packages = find:
+
+[options.package_data]
+lintegrate =
+    *.pxd
 
 [options.extras_require]
 docs =

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ def readfile(filename):
 
 
 def gsl_config(*args, **kwargs):
-    """Run gsl-config and return pre-formatted output
-    """
+    """Run gsl-config and return pre-formatted output"""
     if WINDOWS:
         cmd = "gsl-config {}".format(" ".join(args))
         kwargs.setdefault("shell", True)
@@ -78,30 +77,33 @@ else:
         "-march=native",
         "-funroll-loops",
     ]
-ext_modules = cythonize([
-    Extension(
-        "lintegrate.lintegrate",
-        sources=[
-            "lintegrate/lintegrate.pyx",
-            "src/lintegrate_qag.c",
-            "src/lintegrate_qng.c",
-            "src/lintegrate_cquad.c",
-        ],
-        include_dirs=[
-            numpy.get_include(),
-            gsl_config("--cflags")[2:],
-            "src",
-            "lintegrate",
-        ],
-        library_dirs=[
-            gsl_config("--libs").split(" ")[0][2:],
-        ],
-        libraries=[
-            "gsl",
-        ],
-        extra_compile_args=extra_compile_args,
-    ),
-])
+ext_modules = cythonize(
+    [
+        Extension(
+            "lintegrate.lintegrate",
+            sources=[
+                "lintegrate/lintegrate.pyx",
+                "src/lintegrate_qag.c",
+                "src/lintegrate_qng.c",
+                "src/lintegrate_cquad.c",
+            ],
+            include_dirs=[
+                numpy.get_include(),
+                gsl_config("--cflags")[2:],
+                "src",
+                "lintegrate",
+            ],
+            library_dirs=[
+                gsl_config("--libs").split(" ")[0][2:],
+            ],
+            libraries=[
+                "gsl",
+            ],
+            extra_compile_args=extra_compile_args,
+        ),
+    ],
+    language_level="3",
+)
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ ext_modules = cythonize([
             numpy.get_include(),
             gsl_config("--cflags")[2:],
             "src",
+            "lintegrate",
         ],
         library_dirs=[
             gsl_config("--libs").split(" ")[0][2:],


### PR DESCRIPTION
This PR puts definitions for the `cdef` functions from `lintegrate.pyx` into a `.pxd` file. This means that other packages can `cimport` them in their own `.pyx` files.

The PR also includes a `get_include` function, which can be used to make sure the path to lintegrate can be set. E.g., if you have a `.pyx` file containing:

```
from lintegrate.lintegrate import logplus
```

then you're `setup.py` file might have an extension that looks something like:

```python
import numpy as np
import lintegrate

from setuptools import Extension

...

ext_modules = [
    Extension(
        "mymodule",
        sources=[
            "mymodule.pyx",
        ],
        include_dirs=[
            np.get_include(),
            gsl_config("--cflags")[2:],
            "cwinpy",
            lintegrate.get_include(),
        ],
        library_dirs=[
            gsl_config("--libs").split(" ")[0][2:],
        ],
        libraries=["gsl"],
        extra_compile_args=[
            "-Wall",
            "-O3",
            "-Wextra",
            "-m64",
            "-ffast-math",
            "-fno-finite-math-only",
            "-funroll-loops",
        ],
    ),
]
```