### PR TITLE
Remove march=native from build

### DIFF
--- a/lintegrate/__init__.py
+++ b/lintegrate/__init__.py
@@ -2,7 +2,7 @@ import os
 
 from .lintegrate import *
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"
 
 
 def get_include():

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,6 @@ else:
         "-m64",
         "-ffast-math",
         "-fno-finite-math-only",
-        "-march=native",
         "-funroll-loops",
     ]
 ext_modules = cythonize(


### PR DESCRIPTION
The Python build can fail for tigerlake with some GCC versions when the `march=native` flag is included. This patch removes the use of that flag.

Closes #25 