### PR TITLE
Add noexcept to lintegrate_callback to prevent Cython error

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,18 +18,23 @@ jobs:
         include:
           - os: ubuntu-20.04
             ccompiler: "c-compiler"
+            condainstall: "numpy pip pytest setuptools"
           - os: ubuntu-22.04
-            ccompiler: "c-compiler"
+            ccompiler: "numpy pip pytest setuptools"
           - os: windows-latest
-            ccompiler: "c-compiler"
+            condainstall: "c-compiler cython gsl numpy pip pytest setuptools"
           - os: macos-latest
-            ccompiler: "c-compiler 'clang>=12.0.1'"
+            condainstall: "c-compiler 'clang>=12.0.1' cython gsl numpy pip pytest setuptools"
     runs-on: ${{ matrix.os }}
     defaults:
       run:
         shell: bash -l {0}
 
     steps:
+    - if: ${{ matrix.os }} == 'ubuntu-20.04' || ${{ matrix.os }} == 'ubuntu-22.04'
+      run: |
+        apt install libgsl-dev
+        apt list --installed | grep gsl
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
       with:
@@ -38,7 +43,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        conda install -n test -q -y ${{ matrix.ccompiler }} cython gsl numpy pip pytest setuptools
+        conda install -n test -q -y ${{ matrix.condainstall }}
     - name: Conda information
       run: |
         conda info --all

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10"]
         include:
           - os: ubuntu-20.04
-            condainstall: "numpy pip pytest setuptools"
+            condainstall: "cython numpy pip pytest setuptools"
           - os: ubuntu-22.04
-            condainstall: "numpy pip pytest setuptools"
+            condainstall: "cython numpy pip pytest setuptools"
           - os: windows-latest
             condainstall: "c-compiler cython gsl numpy pip pytest setuptools"
           - os: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,9 @@ jobs:
         python-version: [3.7, 3.8, 3.9, "3.10"]
         include:
           - os: ubuntu-20.04
-            ccompiler: "c-compiler"
             condainstall: "numpy pip pytest setuptools"
           - os: ubuntu-22.04
-            ccompiler: "numpy pip pytest setuptools"
+            condainstall: "numpy pip pytest setuptools"
           - os: windows-latest
             condainstall: "c-compiler cython gsl numpy pip pytest setuptools"
           - os: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
         include:
           - os: ubuntu-20.04
             ccompiler: "c-compiler"
+          - os: ubuntu-22.04
+            ccompiler: "c-compiler"
           - os: windows-latest
             ccompiler: "c-compiler"
           - os: macos-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
         include:
           - os: ubuntu-20.04
             ccompiler: "c-compiler"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - if: ${{ matrix.os }} == 'ubuntu-20.04' || ${{ matrix.os }} == 'ubuntu-22.04'
+    - if: ${{ matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04' }}
       run: |
         apt install libgsl-dev
         apt list --installed | grep gsl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         include:
           - os: ubuntu-20.04
             ccompiler: "c-compiler"

--- a/lintegrate/lintegrate.pyx
+++ b/lintegrate/lintegrate.pyx
@@ -473,6 +473,6 @@ def lcquad(func, a, b, args=(), epsabs=1.49e-8, epsrel=1.49e-8, wsintervals=100,
 
 # callback function to allow python functions to be passed to C lintegration functions
 # (see e.g. https://github.com/cython/cython/tree/master/Demos/callback)
-cdef double lintegrate_callback(double x, void *f, void *args):
+cdef double lintegrate_callback(double x, void *f, void *args) noexcept:
     return (<object>f)(x, <object>args)
 


### PR DESCRIPTION
When trying to install lintegrate from source or from PyPI, it gives errors like:

```
      lintegrate/lintegrate.pyx:461:33: Cannot assign type 'double (double, void *, void *) except? -1' to 'pylintfunc'. Exception values are incompatible. Suggest adding 'noexcept' to type 'double (double, void *, void *) except? -1'.
```

These errors are fixed by this patch.