### PR TITLE
Fix explicit libraries needed to build cython module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ ext_modules = cythonize(
                 gsl_config("--libs").split(" ")[0][2:],
             ],
             libraries=[
-                "gsl",
+                l.replace("-l", "") for l in gsl_config("--libs").split()[1:]
             ],
             extra_compile_args=extra_compile_args,
         ),


### PR DESCRIPTION
In #27 it was found that `"gslcblas"` was not being set as an explicit linked library when building the cython extension. I'm not sure how it was working in some cases without this, but this PR attempts a fix.