### PR TITLE
Use gsl-config --libs-without-cblas when building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,11 +38,12 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         activate-environment: test
-        channels: conda-forge
+        miniforge-variant: Mambaforge
         python-version: ${{ matrix.python-version }}
+        use-mamba: true
     - name: Install dependencies
       run: |
-        conda install -n test -q -y ${{ matrix.condainstall }}
+        mamba install -n test -q -y ${{ matrix.condainstall }}
     - name: Conda information
       run: |
         conda info --all

--- a/setup.py
+++ b/setup.py
@@ -93,10 +93,10 @@ ext_modules = cythonize(
                 "lintegrate",
             ],
             library_dirs=[
-                gsl_config("--libs").split(" ")[0][2:],
+                gsl_config("--libs-without-cblas").split(" ")[0][2:],
             ],
             libraries=[
-                l.replace("-l", "") for l in gsl_config("--libs").split()[1:]
+                l.replace("-l", "") for l in gsl_config("--libs-without-cblas").split()[1:]
             ],
             extra_compile_args=extra_compile_args,
         ),


### PR DESCRIPTION
This PR patches `setup.py` to use the `--libs-without-cblas` option for `gsl-config` (rather than just `--libs`) since this project doesn't actually use cblas.